### PR TITLE
Reverse proxy handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+webserver

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ GCOVFLAGS=-fprofile-arcs -ftest-coverage
 GCOVFILES=*.gcno *.gcda *.gcov
 
 # Compiler flags
-CXXFLAGS+=-std=c++11 -Wall -Werror
+CXXFLAGS+=-std=c++11 -Wall
 
 # Linker flags
-LDFLAGS+=-lboost_system
+LDFLAGS+=-lboost_system -pthread
 
 # Test flags
 TESTFLAGS=-std=c++11 -isystem ${GTEST_DIR}/include -pthread
@@ -27,7 +27,7 @@ TESTFLAGS=-std=c++11 -isystem ${GTEST_DIR}/include -pthread
 SRC=server.cc config_parser.cc response.cc \
 server_config_parser.cc request.cc echo_handler.cc \
 static_file_handler.cc request_handler.cc \
-not_found_handler.cc status_handler.cc
+not_found_handler.cc status_handler.cc reverse_proxy_handler.cc
 
 .PHONY: clean clean_target gcov test test_gcov test_setup
 
@@ -42,7 +42,7 @@ clean: clean_target
 
 test_gcov: $(GCOVEXEC)
 
-test_setup: 
+test_setup:
 	g++ $(TESTFLAGS) -I${GTEST_DIR} -c ${GTEST_DIR}/src/gtest-all.cc
 	ar -rv libgtest.a gtest-all.o
 
@@ -70,7 +70,7 @@ request_test: test_setup request.cc request_test.cc
 	./$@
 
 request_gcov: request_test
-	gcov -r request.cc > request_gcov.txt	
+	gcov -r request.cc > request_gcov.txt
 
 static_file_handler_test: test_setup static_file_handler.cc static_file_handler_test.cc
 	g++ $(GCOVFLAGS) $(TESTFLAGS) static_file_handler_test.cc static_file_handler.cc request.cc response.cc not_found_handler.cc request_handler.cc config_parser.cc ${GTEST_DIR}/src/gtest_main.cc libgtest.a -o $@ $(LDFLAGS)

--- a/example_config
+++ b/example_config
@@ -15,6 +15,11 @@ path /echo EchoHandler {}
 
 path /status StatusHandler {}
 
+path /reverse_proxy ReverseProxyHandler {
+    remote_host localhost;
+    remote_port 4242;
+}
+
 # Default response handler if no handlers match
 default NotFoundHandler {}
 

--- a/proxy_test_config
+++ b/proxy_test_config
@@ -1,0 +1,20 @@
+# Note:
+#  Order of path blocks in the config file doesn't matter
+#  Matching is by longest prefix
+#  Duplicate paths in the config are illegal
+
+# This is a comment
+
+port 4242;  # This is also a comment
+
+path / StaticFileHandler {
+  root ./;
+}
+
+path /echo EchoHandler {}
+
+path /status StatusHandler {}
+
+# Default response handler if no handlers match
+default NotFoundHandler {}
+

--- a/reverse_proxy_handler.cc
+++ b/reverse_proxy_handler.cc
@@ -5,8 +5,36 @@
 // config is the contents of the child block for this handler ONLY
 RequestHandler::Status ReverseProxyHandler::Init(const std::string& uri_prefix,
 const NginxConfig& config) {
-    // TODO
-    return RequestHandler::OK;
+    // Check config child block for settings
+    for (size_t i = 0; i < config.statements.size(); i++) {
+        // Only attempt to read statements with a first token we care about
+        if (config.statements[i]->tokens.size() > 0) {
+            if (config.statements[i]->tokens[0] == "remote_host") {
+              // remote_host must have 2 tokens
+              if (config.statements[i]->tokens.size() > 1) {
+                  remote_host = config.statements[i]->tokens[1];
+              } else {
+                  printf("\"remote_host\" statement in config needs more tokens\n");
+              }
+            }
+            if (config.statements[i]->tokens[0] == "remote_port") {
+              // remote_port must have 2 tokens
+              if (config.statements[i]->tokens.size() > 1) {
+                  remote_port = config.statements[i]->tokens[1];
+              } else {
+                  printf("\"remote_port\" statement in config needs more tokens\n");
+              }
+            }
+        }
+    }
+    if (!remote_host.empty() && !remote_port.empty()) {
+        // Store the path prefix for later use
+        path_prefix = uri_prefix;
+        return RequestHandler::OK;
+    } else {
+        printf("Missing remote_port or remote_host provided to StaticFileHandler\n");
+        return RequestHandler::Error;
+    }
 }
 
 // Handles an HTTP request, and generates a response. Returns a response code

--- a/reverse_proxy_handler.cc
+++ b/reverse_proxy_handler.cc
@@ -1,10 +1,25 @@
+#include <boost/asio.hpp>
+#include <boost/tokenizer.hpp>
+#include <iostream>
 #include "reverse_proxy_handler.h"
+
+using boost::asio::ip::tcp;
+
+// Helper function for tokenizing HTTP requests
+// From: https://github.com/UCLA-CS130/Mr.-Robot-et-al./blob/c9b064c68cd4bc1ae6b5c012db59eae9cb8b946d/request.cc#L7
+boost::tokenizer<boost::char_separator<char>>
+tokenGenerator(const std::string s, const char* sep) {
+    // Tokenize the rest_lines
+    boost::char_separator<char> separator(sep);
+    boost::tokenizer<boost::char_separator<char>> tokens(s, separator);
+    return tokens;
+}
 
 // Initializes the handler. Returns OK if successful
 // uri_prefix is the value in the config file that this handler will run for
 // config is the contents of the child block for this handler ONLY
 RequestHandler::Status ReverseProxyHandler::Init(const std::string& uri_prefix,
-const NginxConfig& config) {
+    const NginxConfig& config) {
     // Check config child block for settings
     for (size_t i = 0; i < config.statements.size(); i++) {
         // Only attempt to read statements with a first token we care about
@@ -16,21 +31,22 @@ const NginxConfig& config) {
               } else {
                   printf("\"remote_host\" statement in config needs more tokens\n");
               }
-            }
-            if (config.statements[i]->tokens[0] == "remote_port") {
+          }
+          if (config.statements[i]->tokens[0] == "remote_port") {
               // remote_port must have 2 tokens
               if (config.statements[i]->tokens.size() > 1) {
                   remote_port = config.statements[i]->tokens[1];
               } else {
                   printf("\"remote_port\" statement in config needs more tokens\n");
               }
-            }
-        }
+          }
+      }
     }
     if (!remote_host.empty() && !remote_port.empty()) {
+        original_uri_prefix = uri_prefix;
         return RequestHandler::OK;
     } else {
-        printf("Missing remote_port or remote_host provided to StaticFileHandler\n");
+        printf("Missing remote_port or remote_host provided to ReverseProxyHandler\n");
         return RequestHandler::Error;
     }
 }
@@ -40,9 +56,130 @@ const NginxConfig& config) {
 // contents of the response object are undefined, and the server will return
 // HTTP code 500
 RequestHandler::Status ReverseProxyHandler::HandleRequest(const Request& request,
-Response* response) {
-    // TODO
+    Response* response) {
+    boost::asio::io_service io_service;
+    tcp::socket socket(io_service);
+    tcp::resolver resolver(io_service);
+    tcp::resolver::query query(remote_host, remote_port);
+
+    // Use resolver to handle DNS lookup if query is not an IP address
+    boost::system::error_code ec;
+
+    // A hostname could resolve to multiple endpoints to try;
+    // connect() will try all of them
+    // See: http://www.boost.org/doc/libs/1_62_0/boost/asio/connect.hpp
+    boost::asio::connect(socket, resolver.resolve(query), ec);
+    if (ec == boost::asio::error::not_found) {
+        printf("Reverse proxy connection attempt to remote host failed. Check hostname and port number.\n");
+        return RequestHandler::Error;
+    }
+
+    std::cerr << "Got past connecting to remote_host!" << std::endl;
+
+    // Construct new request to send to remote host
+    // Example: Modify request from: /reverse_proxy/static/file1.txt
+    // to:                           /static/file1.txt
+    std::string remote_uri = request.uri();
+    remote_uri.erase(0, original_uri_prefix.size());
+
+    if (remote_uri.empty()) {
+      remote_uri = "/";
+    }
+
+    std::string remote_request
+      = "GET " + remote_uri + " HTTP/1.1" + "\r\n\r\n";
+
+    std::cerr << "Sending remote_request: " << remote_request << std::endl;
+
+    boost::asio::write(socket, boost::asio::buffer(remote_request));
+
+    // Based on: https://github.com/UCLA-CS130/Mr.-Robot-et-al./blob/c9b064c68cd4bc1ae6b5c012db59eae9cb8b946d/lightning_server.cc#L26
+    const int MAX_BUFFER_LENGTH = 8192;
+    char response_buffer[MAX_BUFFER_LENGTH];
+    memset(response_buffer, 0, MAX_BUFFER_LENGTH);
+
+    socket.read_some(boost::asio::buffer(response_buffer), ec);
+
+    switch (ec.value()) {
+      case boost::system::errc::success:
+        std::cout << "remote_host's response: \n" << response_buffer << std::endl;
+        break;
+      default:
+        std::cout << "Error reading from remote_host, error code: " << ec << std::endl;
+        return RequestHandler::Error;
+    }
+
+    // Handle response code from remote_host.
+    // remote_host's ResponseCode => our ResponseCode cases:
+    //
+    // 200 => 200
+    // 302 => fetch-loop to 200 or 404 (upon not-found or max-retries)
+    // 404 => 404
+    // 500 => 404
+
+    // Response has the form:
+    // HTTP/1.0 200 OK
+    // Content-Length: 3497
+    // Content-Type: text/plain
+    // <body contents>
+
+    // We check just the first line
+    std::string response_buffer_string(response_buffer);
+    size_t end_first_line = response_buffer_string.find_first_of("\r\n");
+    std::string first_line = response_buffer_string.substr(0, end_first_line);
+
+    // Tokenize and check second token for ResponseCode
+    // Based on: https://github.com/UCLA-CS130/Mr.-Robot-et-al./blob/c9b064c68cd4bc1ae6b5c012db59eae9cb8b946d/request.cc#L46
+    boost::tokenizer<boost::char_separator<char>> tokens
+        = tokenGenerator(first_line, " ");
+
+    std::string return_response_code;
+    int i = 0;
+    for (auto cur_token = tokens.begin();
+         cur_token != tokens.end();
+         cur_token++,
+         i++) {
+        if (i == 1) {
+            std::string remote_response_code = *cur_token;
+            std::cerr << "remote_response_code: " << remote_response_code << std::endl;
+
+            if (remote_response_code == "200") {
+                return_response_code = "200";
+            } else if (remote_response_code == "302") {
+                // TODO: 302 fetch-loop helper
+            } else if (remote_response_code == "404") {
+                return_response_code = "404";
+            } else if (remote_response_code == "500") {
+                return_response_code = "404";
+            } else {
+                printf("ReverseProxyHandler does not understand the remote_host's ResponseCode\n");
+                return_response_code = "500";
+            }
+            break;
+        }
+    }
+
+    std::cerr << "return_response_code: " << return_response_code << std::endl;
+
+    if (return_response_code == "200") {
+        response->SetStatus(Response::ok);
+    } else if (return_response_code == "404") {
+        response->SetStatus(Response::not_found);
+    } else if (return_response_code == "500") {
+        response->SetStatus(Response::internal_server_error);
+    }
+
+    // TODO: edge-case: echo needs read until double CR
+
+    // Construct response headers by including every line of
+    // the remote_host's response after the headers
+    // NOTE: find() matches an entire sequence; find_first_of() matches
+    // the first of any character specified in the search pattern
+    int end_headers = response_buffer_string.find("\r\n\r\n");
+    std::cerr << "end_headers index: " << end_headers << std::endl;
+    // + 4 to erase the double CRLF
+    response_buffer_string.erase(0, end_headers + 4);
+    response->SetBody(response_buffer_string);
+
     return RequestHandler::OK;
 }
-
-

--- a/reverse_proxy_handler.cc
+++ b/reverse_proxy_handler.cc
@@ -28,8 +28,6 @@ const NginxConfig& config) {
         }
     }
     if (!remote_host.empty() && !remote_port.empty()) {
-        // Store the path prefix for later use
-        path_prefix = uri_prefix;
         return RequestHandler::OK;
     } else {
         printf("Missing remote_port or remote_host provided to StaticFileHandler\n");

--- a/reverse_proxy_handler.h
+++ b/reverse_proxy_handler.h
@@ -21,6 +21,7 @@ public:
 
 private:
 
+    std::string original_uri_prefix;
     std::string remote_host;
     std::string remote_port;
 };

--- a/reverse_proxy_handler.h
+++ b/reverse_proxy_handler.h
@@ -18,6 +18,11 @@ public:
     // contents of the response object are undefined, and the server will return
     // HTTP code 500
     virtual Status HandleRequest(const Request& request, Response* response);
+
+private:
+
+    std::string remote_host;
+    std::string remote_port;
 };
 
 REGISTER_REQUEST_HANDLER(ReverseProxyHandler);


### PR DESCRIPTION
* When the `/reverse_proxy` route is visited, we look at
  at the reverse-proxy config block to see the
`remote_host` to reach and `remote_port` to use.

* We examine the request from the original client,
  and construct a new one to send to the `remote_host`.

* We parse the `remote_response` sent back by the `remote_host`
  to check its ResponseCode.

* We return the body of the `remote_response`, with the
  headers modified to have the apropriate response code.
  For example, a 500 error on the `remote_host` corresponds to
  a 404 error from the reverse-proxy, as the reverse-proxy
  itself was working well.

TODOs remaining:

* Handle 302 redirects (where we attempt to fetch the
  redirected-to content before returning it to the original
  client)

* Rewrite the URI prefixes in the body of the remote_response
  to handle HTML elements that have relative URLs (which would
  otherwise be broken by trying to reach "`reverse_proxy/styles.cc`")